### PR TITLE
Load the webpage of the Profile or the Repository selected

### DIFF
--- a/app/src/main/java/com/globant/practice/di/ApplicationComponent.java
+++ b/app/src/main/java/com/globant/practice/di/ApplicationComponent.java
@@ -4,6 +4,7 @@ import com.globant.practice.presentation.view.activity.HomeActivity;
 import com.globant.practice.presentation.view.activity.SplashActivity;
 import com.globant.practice.presentation.view.fragment.SubscriberDetailsFragment;
 import com.globant.practice.presentation.view.fragment.SubscriberListFragment;
+import com.globant.practice.presentation.view.fragment.WebClientFragment;
 import javax.inject.Singleton;
 import dagger.Component;
 
@@ -43,4 +44,11 @@ public interface ApplicationComponent {
      * @param fragment is the type SubscriberDetailsFragment
      */
     void inject(SubscriberDetailsFragment fragment);
+
+    /**
+     * Inject method for the WebClientFragment
+     *
+     * @param fragment is the type WebClientFragment
+     */
+    void inject(WebClientFragment fragment);
 }

--- a/app/src/main/java/com/globant/practice/di/PracticeModule.java
+++ b/app/src/main/java/com/globant/practice/di/PracticeModule.java
@@ -1,15 +1,7 @@
 package com.globant.practice.di;
 
 import com.globant.practice.BuildConfig;
-import com.globant.practice.domain.interactor.FetchSubscriberProfileInteractor;
-import com.globant.practice.domain.interactor.FetchSubscriberRepositoriesInteractor;
-import com.globant.practice.domain.interactor.FetchUsersInteractor;
 import com.globant.practice.domain.service.GitHubApi;
-import com.globant.practice.presentation.presenter.HomePresenter;
-import com.globant.practice.presentation.presenter.SplashPresenter;
-import com.globant.practice.presentation.presenter.SubscriberDetailsPresenter;
-import com.globant.practice.presentation.presenter.SubscriberListPresenter;
-import com.globant.practice.presentation.presenter.WebClientPresenter;
 import javax.inject.Singleton;
 import dagger.Module;
 import dagger.Provides;
@@ -23,64 +15,6 @@ import retrofit2.converter.gson.GsonConverterFactory;
  */
 @Module
 public class PracticeModule {
-
-    /**
-     * Returns a unique reference of SplashPresenter.
-     *
-     * @return SplashPresenter reference
-     */
-    @Provides
-    @Singleton
-    SplashPresenter provideSplashPresenter() {
-        return new SplashPresenter();
-    }
-
-    /**
-     * Returns a unique reference of SubscriberListPresenter.
-     *
-     * @param interactor needs an UsersInteractor reference
-     * @return SubscriberListPresenter reference
-     */
-    @Provides
-    @Singleton
-    SubscriberListPresenter provideSubscriberListPresenter(FetchUsersInteractor interactor) {
-        return new SubscriberListPresenter(interactor);
-    }
-
-    /**
-     * Returns a unique reference of HomePresenter
-     *
-     * @return HomePresenter reference
-     */
-    @Provides
-    @Singleton
-    HomePresenter provideHomePresenter() {
-        return new HomePresenter();
-    }
-
-    /**
-     * Returns a unique reference of SubscriberDetailsPresenter
-     *
-     * @param profileInteractor      needs a profileInteractor reference
-     * @param repositoriesInteractor needs a repositoriesInteractor reference
-     * @return SubscriberDetailsPresenter reference
-     */
-    @Provides
-    @Singleton
-    SubscriberDetailsPresenter provideSubscriberDetailsPresenter(FetchSubscriberProfileInteractor profileInteractor, FetchSubscriberRepositoriesInteractor repositoriesInteractor) {
-        return new SubscriberDetailsPresenter(profileInteractor, repositoriesInteractor);
-    }
-
-    /**
-     * Returns a unique reference of the WebClientPresenter
-     *
-     * @return WebClientPresenter reference
-     */
-    @Provides
-    @Singleton
-    WebClientPresenter provideWebClientPresenter() {
-        return new WebClientPresenter();
-    }
 
     /**
      * Returns a unique reference of retrofit.

--- a/app/src/main/java/com/globant/practice/di/PracticeModule.java
+++ b/app/src/main/java/com/globant/practice/di/PracticeModule.java
@@ -9,6 +9,7 @@ import com.globant.practice.presentation.presenter.HomePresenter;
 import com.globant.practice.presentation.presenter.SplashPresenter;
 import com.globant.practice.presentation.presenter.SubscriberDetailsPresenter;
 import com.globant.practice.presentation.presenter.SubscriberListPresenter;
+import com.globant.practice.presentation.presenter.WebClientPresenter;
 import javax.inject.Singleton;
 import dagger.Module;
 import dagger.Provides;
@@ -68,6 +69,17 @@ public class PracticeModule {
     @Singleton
     SubscriberDetailsPresenter provideSubscriberDetailsPresenter(FetchSubscriberProfileInteractor profileInteractor, FetchSubscriberRepositoriesInteractor repositoriesInteractor) {
         return new SubscriberDetailsPresenter(profileInteractor, repositoriesInteractor);
+    }
+
+    /**
+     * Returns a unique reference of the WebClientPresenter
+     *
+     * @return WebClientPresenter reference
+     */
+    @Provides
+    @Singleton
+    WebClientPresenter provideWebClientPresenter() {
+        return new WebClientPresenter();
     }
 
     /**

--- a/app/src/main/java/com/globant/practice/presentation/model/HomeViewState.java
+++ b/app/src/main/java/com/globant/practice/presentation/model/HomeViewState.java
@@ -9,6 +9,7 @@ import android.app.Fragment;
 
 public class HomeViewState {
     private Fragment fragment;
+    private boolean firstTimeToRun;
 
     /**
      * Gets the fragment instance
@@ -20,11 +21,29 @@ public class HomeViewState {
     }
 
     /**
+     * Indicates if  is the first time that the application run
+     *
+     * @return true if is the first time if not false
+     */
+    public boolean isFirstTimeToRun() {
+        return firstTimeToRun;
+    }
+
+    /**
      * Sets the fragment instance
      *
      * @param fragment fragment instance
      */
     public void setFragment(Fragment fragment) {
         this.fragment = fragment;
+    }
+
+    /**
+     * Sets the new value of firstTimeToRun
+     *
+     * @param firstTimeToRun Indicates if is the first time that the application run
+     */
+    public void setFirstTimeToRun(boolean firstTimeToRun) {
+        this.firstTimeToRun = firstTimeToRun;
     }
 }

--- a/app/src/main/java/com/globant/practice/presentation/model/WebClientState.java
+++ b/app/src/main/java/com/globant/practice/presentation/model/WebClientState.java
@@ -7,7 +7,6 @@ package com.globant.practice.presentation.model;
 
 public class WebClientState {
     private String htmlUrl;
-    private String detailType;
     private boolean loading;
     private String error;
     private boolean errorShowing;
@@ -19,15 +18,6 @@ public class WebClientState {
      */
     public void setHtmlUrl(String htmlUrl) {
         this.htmlUrl = htmlUrl;
-    }
-
-    /**
-     * Sets the new value of the detailType
-     *
-     * @param detailType new value of the detailType
-     */
-    public void setDetailType(String detailType) {
-        this.detailType = detailType;
     }
 
     /**
@@ -64,15 +54,6 @@ public class WebClientState {
      */
     public String getHtmlUrl() {
         return htmlUrl;
-    }
-
-    /**
-     * Gets the type of the web page (Profile or Repository)
-     *
-     * @return the type of the web page
-     */
-    public String getDetailType() {
-        return detailType;
     }
 
     /**

--- a/app/src/main/java/com/globant/practice/presentation/model/WebClientState.java
+++ b/app/src/main/java/com/globant/practice/presentation/model/WebClientState.java
@@ -1,7 +1,5 @@
 package com.globant.practice.presentation.model;
 
-import android.os.Bundle;
-
 /**
  * Manages the states of the WebClientFragment
  * Created by jonathan.vargas on 4/05/2017.
@@ -13,7 +11,6 @@ public class WebClientState {
     private boolean loading;
     private String error;
     private boolean errorShowing;
-    private Bundle webViewState;
 
     /**
      * Sets the new value of the htmlUrl
@@ -61,15 +58,6 @@ public class WebClientState {
     }
 
     /**
-     * Sets the new value of the webViewState bundle
-     *
-     * @param webViewState new value of the webViewState bundle
-     */
-    public void setWebViewState(Bundle webViewState) {
-        this.webViewState = webViewState;
-    }
-
-    /**
      * Gets the address of the web page that will be load
      *
      * @return web page address
@@ -112,14 +100,5 @@ public class WebClientState {
      */
     public boolean isErrorShowing() {
         return errorShowing;
-    }
-
-    /**
-     * Gets the state of the webClientWebView
-     *
-     * @return state of the webClientWebView
-     */
-    public Bundle getWebViewState() {
-        return webViewState;
     }
 }

--- a/app/src/main/java/com/globant/practice/presentation/model/WebClientState.java
+++ b/app/src/main/java/com/globant/practice/presentation/model/WebClientState.java
@@ -1,0 +1,66 @@
+package com.globant.practice.presentation.model;
+
+/**
+ * Manages the states of the WebClientFragment
+ * Created by jonathan.vargas on 4/05/2017.
+ */
+
+public class WebClientState {
+    private String htmlUrl;
+    private String detailType;
+    private boolean loading;
+
+    /**
+     * Sets the new value of the htmlUrl
+     *
+     * @param htmlUrl new value of the htmlUrl
+     */
+    public void setHtmlUrl(String htmlUrl) {
+        this.htmlUrl = htmlUrl;
+    }
+
+    /**
+     * Sets the new value of the detailType
+     *
+     * @param detailType new value of the detailType
+     */
+    public void setDetailType(String detailType) {
+        this.detailType = detailType;
+    }
+
+    /**
+     * Sets the new value of the loading boolean
+     *
+     * @param loading new value of the loading boolean
+     */
+    public void setLoading(boolean loading) {
+        this.loading = loading;
+    }
+
+    /**
+     * Gets the address of the web page that will be load
+     *
+     * @return web page address
+     */
+    public String getHtmlUrl() {
+        return htmlUrl;
+    }
+
+    /**
+     * Gets the type of the web page (Profile or Repository)
+     *
+     * @return the type of the web page
+     */
+    public String getDetailType() {
+        return detailType;
+    }
+
+    /**
+     * Indicates if the ProgressDialog is showing or not
+     *
+     * @return true if the ProgressDialog is showing if not return false
+     */
+    public boolean isLoading() {
+        return loading;
+    }
+}

--- a/app/src/main/java/com/globant/practice/presentation/model/WebClientState.java
+++ b/app/src/main/java/com/globant/practice/presentation/model/WebClientState.java
@@ -1,5 +1,7 @@
 package com.globant.practice.presentation.model;
 
+import android.os.Bundle;
+
 /**
  * Manages the states of the WebClientFragment
  * Created by jonathan.vargas on 4/05/2017.
@@ -11,6 +13,7 @@ public class WebClientState {
     private boolean loading;
     private String error;
     private boolean errorShowing;
+    private Bundle webViewState;
 
     /**
      * Sets the new value of the htmlUrl
@@ -58,6 +61,15 @@ public class WebClientState {
     }
 
     /**
+     * Sets the new value of the webViewState bundle
+     *
+     * @param webViewState new value of the webViewState bundle
+     */
+    public void setWebViewState(Bundle webViewState) {
+        this.webViewState = webViewState;
+    }
+
+    /**
      * Gets the address of the web page that will be load
      *
      * @return web page address
@@ -100,5 +112,14 @@ public class WebClientState {
      */
     public boolean isErrorShowing() {
         return errorShowing;
+    }
+
+    /**
+     * Gets the state of the webClientWebView
+     *
+     * @return state of the webClientWebView
+     */
+    public Bundle getWebViewState() {
+        return webViewState;
     }
 }

--- a/app/src/main/java/com/globant/practice/presentation/model/WebClientState.java
+++ b/app/src/main/java/com/globant/practice/presentation/model/WebClientState.java
@@ -9,6 +9,8 @@ public class WebClientState {
     private String htmlUrl;
     private String detailType;
     private boolean loading;
+    private String error;
+    private boolean errorShowing;
 
     /**
      * Sets the new value of the htmlUrl
@@ -38,6 +40,24 @@ public class WebClientState {
     }
 
     /**
+     * Sets the new value of the error message
+     *
+     * @param error new value of error message
+     */
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    /**
+     * Sets the new value of the errorShowing boolean
+     *
+     * @param erroShowing new value of the errorShowing boolean
+     */
+    public void setErrorShowing(boolean erroShowing) {
+        this.errorShowing = erroShowing;
+    }
+
+    /**
      * Gets the address of the web page that will be load
      *
      * @return web page address
@@ -62,5 +82,23 @@ public class WebClientState {
      */
     public boolean isLoading() {
         return loading;
+    }
+
+    /**
+     * Gets the error message
+     *
+     * @return error message
+     */
+    public String getError() {
+        return error;
+    }
+
+    /**
+     * Indicates if the error message is  showing or not
+     *
+     * @return true if the error message is showing if not return false
+     */
+    public boolean isErrorShowing() {
+        return errorShowing;
     }
 }

--- a/app/src/main/java/com/globant/practice/presentation/presenter/HomePresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/HomePresenter.java
@@ -4,6 +4,7 @@ import com.globant.practice.presentation.model.HomeViewState;
 import com.globant.practice.presentation.view.activity.HomeView;
 import com.globant.practice.presentation.view.fragment.SubscriberDetailsFragment;
 import com.globant.practice.presentation.view.fragment.SubscriberListFragment;
+import com.globant.practice.presentation.view.fragment.WebClientFragment;
 import javax.inject.Inject;
 
 /**
@@ -42,6 +43,19 @@ public class HomePresenter extends BasePresenter<HomeView> {
      */
     public void subscriberSelected(String login) {
         homeViewState.setFragment(SubscriberDetailsFragment.newInstance(login));
+        if (isViewAttached()) {
+            view.render(homeViewState);
+        }
+    }
+
+    /**
+     * Creates a new instance of WebClientFragment and render it on the view
+     *
+     * @param htmlUrl    url of the web page that will be load on the WebView
+     * @param detailType Indicates if the web page load are a repository or a profile
+     */
+    public void detailSelected(String htmlUrl, String detailType) {
+        homeViewState.setFragment(WebClientFragment.newInstance(htmlUrl, detailType));
         if (isViewAttached()) {
             view.render(homeViewState);
         }

--- a/app/src/main/java/com/globant/practice/presentation/presenter/HomePresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/HomePresenter.java
@@ -26,14 +26,12 @@ public class HomePresenter extends BasePresenter<HomeView> {
     }
 
     /**
-     * Receives and assign an instance of the view interface and render the HomeActivity
-     *
-     * @param view instance of the view interface
+     * Renders the SubscriberListFragment on the view
      */
-    @Override
-    public void attachView(HomeView view) {
-        super.attachView(view);
-        view.render(homeViewState);
+    public void navigateToSubscriberListFragment() {
+        if (homeViewState.isFirstTimeToRun()) {
+            view.render(homeViewState);
+        }
     }
 
     /**
@@ -59,5 +57,14 @@ public class HomePresenter extends BasePresenter<HomeView> {
         if (isViewAttached()) {
             view.render(homeViewState);
         }
+    }
+
+    /**
+     * Sets the value of the firstTimeToRun boolean
+     *
+     * @param firstTimeToRun new value of the firstTimeToRun boolean
+     */
+    public void setFirstTimeToRun(boolean firstTimeToRun) {
+        homeViewState.setFirstTimeToRun(firstTimeToRun);
     }
 }

--- a/app/src/main/java/com/globant/practice/presentation/presenter/SubscriberDetailsPresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/SubscriberDetailsPresenter.java
@@ -120,24 +120,21 @@ public class SubscriberDetailsPresenter extends BasePresenter<SubscriberDetailsV
      */
     public void fetchSubscriberDetails(String login) {
         subscriberDetailsState.setLogin(login);
-        if (subscriberDetailsState.getProfile() != null && subscriberDetailsState.getSubscriberRepositories() != null) {
-            subscriberDetailsState.setError(null);
-            subscriberDetailsState.setLoading(false);
-            if (isViewAttached()) {
-                view.render(subscriberDetailsState);
-            }
-        } else {
+        if (!subscriberDetailsState.isLoading() && subscriberDetailsState.getProfile() == null && subscriberDetailsState.getSubscriberRepositories() == null) {
             subscriberDetailsState.setError(null);
             subscriberDetailsState.setProfile(null);
             subscriberDetailsState.setSubscriberRepositories(null);
             subscriberDetailsState.setLoading(true);
-            if (isViewAttached()) {
-                view.render(subscriberDetailsState);
-                subscriberProfileObservable = profileInteractor.execute(subscriberDetailsState.getLogin());
-                subscriberProfileObservable.subscribeOn(Schedulers.newThread())
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe(getSubscriberProfile);
-            }
+            subscriberProfileObservable = profileInteractor.execute(subscriberDetailsState.getLogin());
+            subscriberProfileObservable.subscribeOn(Schedulers.newThread())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(getSubscriberProfile);
+        } else if (subscriberDetailsState.getProfile() != null && subscriberDetailsState.getSubscriberRepositories() != null) {
+            subscriberDetailsState.setError(null);
+            subscriberDetailsState.setLoading(false);
+        }
+        if (isViewAttached()) {
+            view.render(subscriberDetailsState);
         }
     }
 

--- a/app/src/main/java/com/globant/practice/presentation/presenter/SubscriberDetailsPresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/SubscriberDetailsPresenter.java
@@ -28,8 +28,6 @@ public class SubscriberDetailsPresenter extends BasePresenter<SubscriberDetailsV
     private Observable<Profile> subscriberProfileObservable;
     private Observable<List<Repository>> subscriberRepositoryListObservable;
     private SubscriberDetailsState subscriberDetailsState;
-    private Profile subscriberProfile;
-    private List<Repository> subscriberRepositories;
 
     /**
      * Manages the callback of the profileInteractor call and initializes the repositoriesInteractor
@@ -44,7 +42,7 @@ public class SubscriberDetailsPresenter extends BasePresenter<SubscriberDetailsV
 
         @Override
         public void onNext(Profile profile) {
-            subscriberProfile = profile;
+            subscriberDetailsState.setProfile(profile);
             fetchSubscriberRepositories();
         }
 
@@ -75,10 +73,8 @@ public class SubscriberDetailsPresenter extends BasePresenter<SubscriberDetailsV
 
         @Override
         public void onNext(List<Repository> repositories) {
-            subscriberRepositories = repositories;
+            subscriberDetailsState.setSubscriberRepositories(repositories);
             subscriberDetailsState.setError(null);
-            subscriberDetailsState.setProfile(subscriberProfile);
-            subscriberDetailsState.setSubscriberRepositories(subscriberRepositories);
             subscriberDetailsState.setLoading(false);
             if (isViewAttached()) {
                 view.render(subscriberDetailsState);
@@ -124,10 +120,8 @@ public class SubscriberDetailsPresenter extends BasePresenter<SubscriberDetailsV
      */
     public void fetchSubscriberDetails(String login) {
         subscriberDetailsState.setLogin(login);
-        if (subscriberProfile != null && subscriberRepositories != null) {
+        if (subscriberDetailsState.getProfile() != null && subscriberDetailsState.getSubscriberRepositories() != null) {
             subscriberDetailsState.setError(null);
-            subscriberDetailsState.setProfile(subscriberProfile);
-            subscriberDetailsState.setSubscriberRepositories(subscriberRepositories);
             subscriberDetailsState.setLoading(false);
             if (isViewAttached()) {
                 view.render(subscriberDetailsState);

--- a/app/src/main/java/com/globant/practice/presentation/presenter/SubscriberDetailsPresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/SubscriberDetailsPresenter.java
@@ -124,7 +124,7 @@ public class SubscriberDetailsPresenter extends BasePresenter<SubscriberDetailsV
      */
     public void fetchSubscriberDetails(String login) {
         subscriberDetailsState.setLogin(login);
-        if (subscriberDetailsState.isLoading() && subscriberProfile != null && subscriberRepositories != null) {
+        if (subscriberProfile != null && subscriberRepositories != null) {
             subscriberDetailsState.setError(null);
             subscriberDetailsState.setProfile(subscriberProfile);
             subscriberDetailsState.setSubscriberRepositories(subscriberRepositories);

--- a/app/src/main/java/com/globant/practice/presentation/presenter/SubscriberDetailsPresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/SubscriberDetailsPresenter.java
@@ -129,9 +129,6 @@ public class SubscriberDetailsPresenter extends BasePresenter<SubscriberDetailsV
             subscriberProfileObservable.subscribeOn(Schedulers.newThread())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(getSubscriberProfile);
-        } else if (subscriberDetailsState.getProfile() != null && subscriberDetailsState.getSubscriberRepositories() != null) {
-            subscriberDetailsState.setError(null);
-            subscriberDetailsState.setLoading(false);
         }
         if (isViewAttached()) {
             view.render(subscriberDetailsState);

--- a/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
@@ -24,13 +24,11 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
     /**
      * Initializes the web page load progress
      *
-     * @param htmlUrl    address of the web page that will be load
-     * @param detailType indicates if the web page are a profile or a repository
+     * @param htmlUrl address of the web page that will be load
      */
-    public void loadWebPage(String htmlUrl, String detailType) {
+    public void loadWebPage(String htmlUrl) {
         if (!webClientState.isLoading()) {
             webClientState.setHtmlUrl(htmlUrl);
-            webClientState.setDetailType(detailType);
             webClientState.setLoading(true);
             webClientState.setErrorShowing(false);
             webClientState.setError(null);

--- a/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
@@ -1,0 +1,70 @@
+package com.globant.practice.presentation.presenter;
+
+import com.globant.practice.presentation.model.WebClientState;
+import com.globant.practice.presentation.view.fragment.WebClientView;
+import javax.inject.Inject;
+
+/**
+ * Manages the possible states of the WebClientFragment using a view model called WebClientState,
+ * load the web page on the WebView and shows o dismiss the progress dialog on the WebClientFragment
+ * Created by jonathan.vargas on 4/05/2017.
+ */
+
+public class WebClientPresenter extends BasePresenter<WebClientView> {
+    private WebClientState webClientState;
+
+    /**
+     * Construct method of the WebClientPresenter and initializes the WebClientState model
+     */
+    @Inject
+    public WebClientPresenter() {
+        webClientState = new WebClientState();
+    }
+
+    /**
+     * Initializes the web page load progress
+     *
+     * @param htmlUrl    address of the web page that will be load
+     * @param detailType indicates if the web page are a profile or a repository
+     */
+    public void getWebPage(String htmlUrl, String detailType) {
+        webClientState.setHtmlUrl(htmlUrl);
+        webClientState.setDetailType(detailType);
+        webClientState.setLoading(true);
+        if (isViewAttached()) {
+            view.render(webClientState);
+        }
+
+    }
+
+    /**
+     * Indicates that the web page is completely load on the WebView, works to dismiss the progress
+     * dialog
+     */
+    public void getWebPageCompleted() {
+        webClientState.setLoading(false);
+        if (isViewAttached()) {
+            view.render(webClientState);
+        }
+    }
+
+    /**
+     * Indicates that the web page load has a error, works to dismiss the progress dialog
+     */
+    public void getWebPageError() {
+        webClientState.setLoading(false);
+        if (isViewAttached()) {
+            view.render(webClientState);
+        }
+    }
+
+    /**
+     * Indicates that the WebClient fragments are onPause state, works to dismiss the progress dialog
+     */
+    public void viewOnPauseState() {
+        webClientState.setLoading(false);
+        if (isViewAttached()) {
+            view.render(webClientState);
+        }
+    }
+}

--- a/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
@@ -1,6 +1,5 @@
 package com.globant.practice.presentation.presenter;
 
-import android.os.Bundle;
 import com.globant.practice.presentation.model.WebClientState;
 import com.globant.practice.presentation.view.fragment.WebClientView;
 import javax.inject.Inject;
@@ -29,7 +28,7 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
      * @param detailType indicates if the web page are a profile or a repository
      */
     public void loadWebPage(String htmlUrl, String detailType) {
-        if (!webClientState.isLoading() && webClientState.getWebViewState() == null) {
+        if (!webClientState.isLoading()) {
             webClientState.setHtmlUrl(htmlUrl);
             webClientState.setDetailType(detailType);
             webClientState.setLoading(true);
@@ -49,7 +48,6 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
         webClientState.setLoading(false);
         webClientState.setErrorShowing(false);
         webClientState.setError(null);
-        webClientState.setWebViewState(null);
         if (isViewAttached()) {
             view.render(webClientState);
         }
@@ -63,19 +61,9 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
             webClientState.setLoading(false);
             webClientState.setErrorShowing(true);
             webClientState.setError(view.getErrorMessageText());
-            webClientState.setWebViewState(null);
             if (isViewAttached()) {
                 view.render(webClientState);
             }
         }
-    }
-
-    /**
-     * Save the webViewState into the WebClientState
-     *
-     * @param webViewState state of the webClientWebView
-     */
-    public void setWebViewState(Bundle webViewState) {
-        webClientState.setWebViewState(webViewState);
     }
 }

--- a/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
@@ -27,22 +27,25 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
      * @param htmlUrl    address of the web page that will be load
      * @param detailType indicates if the web page are a profile or a repository
      */
-    public void getWebPage(String htmlUrl, String detailType) {
-        webClientState.setHtmlUrl(htmlUrl);
-        webClientState.setDetailType(detailType);
-        webClientState.setLoading(true);
-        if (isViewAttached()) {
-            view.render(webClientState);
+    public void loadWebPage(String htmlUrl, String detailType) {
+        if (!webClientState.isLoading()) {
+            webClientState.setHtmlUrl(htmlUrl);
+            webClientState.setDetailType(detailType);
+            webClientState.setLoading(true);
+            webClientState.setErrorShowing(false);
+            if (isViewAttached()) {
+                view.render(webClientState);
+            }
         }
-
     }
 
     /**
      * Indicates that the web page is completely load on the WebView, works to dismiss the progress
      * dialog
      */
-    public void getWebPageCompleted() {
+    public void webPageLoadComplete() {
         webClientState.setLoading(false);
+        webClientState.setErrorShowing(false);
         if (isViewAttached()) {
             view.render(webClientState);
         }
@@ -51,10 +54,14 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
     /**
      * Indicates that the web page load has a error, works to dismiss the progress dialog
      */
-    public void getWebPageError() {
-        webClientState.setLoading(false);
-        if (isViewAttached()) {
-            view.render(webClientState);
+    public void webPageError(String failingUrl) {
+        if (failingUrl.equals(webClientState.getHtmlUrl()) && !webClientState.isErrorShowing()) {
+            webClientState.setLoading(false);
+            webClientState.setErrorShowing(true);
+            webClientState.setError(view.getErrorMessageText());
+            if (isViewAttached()) {
+                view.render(webClientState);
+            }
         }
     }
 

--- a/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
@@ -28,14 +28,13 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
      * @param detailType indicates if the web page are a profile or a repository
      */
     public void loadWebPage(String htmlUrl, String detailType) {
-        if (!webClientState.isLoading()) {
-            webClientState.setHtmlUrl(htmlUrl);
-            webClientState.setDetailType(detailType);
-            webClientState.setLoading(true);
-            webClientState.setErrorShowing(false);
-            if (isViewAttached()) {
-                view.render(webClientState);
-            }
+        webClientState.setHtmlUrl(htmlUrl);
+        webClientState.setDetailType(detailType);
+        webClientState.setLoading(true);
+        webClientState.setErrorShowing(false);
+        webClientState.setError(null);
+        if (isViewAttached()) {
+            view.render(webClientState);
         }
     }
 
@@ -46,6 +45,7 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
     public void webPageLoadComplete() {
         webClientState.setLoading(false);
         webClientState.setErrorShowing(false);
+        webClientState.setError(null);
         if (isViewAttached()) {
             view.render(webClientState);
         }
@@ -68,10 +68,12 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
     /**
      * Indicates that the WebClient fragments are onPause state, works to dismiss the progress dialog
      */
-    public void viewOnPauseState() {
+    @Override
+    public void detachView() {
         webClientState.setLoading(false);
         if (isViewAttached()) {
             view.render(webClientState);
         }
+        super.detachView();
     }
 }

--- a/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
+++ b/app/src/main/java/com/globant/practice/presentation/presenter/WebClientPresenter.java
@@ -1,5 +1,6 @@
 package com.globant.practice.presentation.presenter;
 
+import android.os.Bundle;
 import com.globant.practice.presentation.model.WebClientState;
 import com.globant.practice.presentation.view.fragment.WebClientView;
 import javax.inject.Inject;
@@ -28,11 +29,13 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
      * @param detailType indicates if the web page are a profile or a repository
      */
     public void loadWebPage(String htmlUrl, String detailType) {
-        webClientState.setHtmlUrl(htmlUrl);
-        webClientState.setDetailType(detailType);
-        webClientState.setLoading(true);
-        webClientState.setErrorShowing(false);
-        webClientState.setError(null);
+        if (!webClientState.isLoading() && webClientState.getWebViewState() == null) {
+            webClientState.setHtmlUrl(htmlUrl);
+            webClientState.setDetailType(detailType);
+            webClientState.setLoading(true);
+            webClientState.setErrorShowing(false);
+            webClientState.setError(null);
+        }
         if (isViewAttached()) {
             view.render(webClientState);
         }
@@ -46,6 +49,7 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
         webClientState.setLoading(false);
         webClientState.setErrorShowing(false);
         webClientState.setError(null);
+        webClientState.setWebViewState(null);
         if (isViewAttached()) {
             view.render(webClientState);
         }
@@ -59,6 +63,7 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
             webClientState.setLoading(false);
             webClientState.setErrorShowing(true);
             webClientState.setError(view.getErrorMessageText());
+            webClientState.setWebViewState(null);
             if (isViewAttached()) {
                 view.render(webClientState);
             }
@@ -66,14 +71,11 @@ public class WebClientPresenter extends BasePresenter<WebClientView> {
     }
 
     /**
-     * Indicates that the WebClient fragments are onPause state, works to dismiss the progress dialog
+     * Save the webViewState into the WebClientState
+     *
+     * @param webViewState state of the webClientWebView
      */
-    @Override
-    public void detachView() {
-        webClientState.setLoading(false);
-        if (isViewAttached()) {
-            view.render(webClientState);
-        }
-        super.detachView();
+    public void setWebViewState(Bundle webViewState) {
+        webClientState.setWebViewState(webViewState);
     }
 }

--- a/app/src/main/java/com/globant/practice/presentation/view/activity/HomeActivity.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/activity/HomeActivity.java
@@ -18,7 +18,6 @@ import javax.inject.Inject;
  * Created by jonathan.vargas on 31/03/2017.
  */
 public class HomeActivity extends AppCompatActivity implements HomeView, SubscriberListFragment.SubscriberListFragmentActions, SubscriberDetailsFragment.SubscriberDetailsActions {
-
     @Inject
     HomePresenter presenter;
 
@@ -32,15 +31,17 @@ public class HomeActivity extends AppCompatActivity implements HomeView, Subscri
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_home);
         ((PracticeApplication) getApplication()).getApplicationComponent().inject(this);
+        presenter.setFirstTimeToRun(savedInstanceState == null);
     }
 
     /**
-     * Attach the view with the presenter.
+     * Attach the view with the presenter and navigate to SubscriberListFragment
      */
     @Override
     protected void onResume() {
         super.onResume();
         presenter.attachView(this);
+        presenter.navigateToSubscriberListFragment();
     }
 
     /**

--- a/app/src/main/java/com/globant/practice/presentation/view/activity/HomeActivity.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/activity/HomeActivity.java
@@ -8,6 +8,7 @@ import com.globant.practice.PracticeApplication;
 import com.globant.practice.R;
 import com.globant.practice.presentation.model.HomeViewState;
 import com.globant.practice.presentation.presenter.HomePresenter;
+import com.globant.practice.presentation.view.fragment.SubscriberDetailsFragment;
 import com.globant.practice.presentation.view.fragment.SubscriberListFragment;
 import javax.inject.Inject;
 
@@ -16,7 +17,7 @@ import javax.inject.Inject;
  * with the presenter.
  * Created by jonathan.vargas on 31/03/2017.
  */
-public class HomeActivity extends AppCompatActivity implements HomeView, SubscriberListFragment.SubscriberListFragmentActions {
+public class HomeActivity extends AppCompatActivity implements HomeView, SubscriberListFragment.SubscriberListFragmentActions, SubscriberDetailsFragment.SubscriberDetailsActions {
 
     @Inject
     HomePresenter presenter;
@@ -79,5 +80,27 @@ public class HomeActivity extends AppCompatActivity implements HomeView, Subscri
     private void setFragment(Fragment fragment) {
         getFragmentManager().beginTransaction()
                 .replace(R.id.content, fragment).commit();
+    }
+
+    /**
+     * Indicates that the user wants to see the profile of the subscriber
+     *
+     * @param htmlUrl    url with the profile address of the subscriber
+     * @param detailType Indicates the detail type of the user wants to see, in this case profile
+     */
+    @Override
+    public void nameSelected(String htmlUrl, String detailType) {
+        presenter.detailSelected(htmlUrl, detailType);
+    }
+
+    /**
+     * Indicates that the user wants to see the repository of the subscriber
+     *
+     * @param htmlUrl    url with the repository address of the subscriber
+     * @param detailType Indicates the detail type of the user wants to see, in this case repository
+     */
+    @Override
+    public void repositorySelected(String htmlUrl, String detailType) {
+        presenter.detailSelected(htmlUrl, detailType);
     }
 }

--- a/app/src/main/java/com/globant/practice/presentation/view/fragment/SubscriberDetailsFragment.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/fragment/SubscriberDetailsFragment.java
@@ -116,8 +116,8 @@ public class SubscriberDetailsFragment extends Fragment implements SubscriberDet
      * Detach the view to the presenter
      */
     @Override
-    public void onDetach() {
-        super.onDetach();
+    public void onPause() {
+        super.onPause();
         presenter.detachView();
     }
 

--- a/app/src/main/java/com/globant/practice/presentation/view/fragment/SubscriberDetailsFragment.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/fragment/SubscriberDetailsFragment.java
@@ -2,6 +2,7 @@ package com.globant.practice.presentation.view.fragment;
 
 import android.app.Fragment;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -19,7 +20,6 @@ import com.globant.practice.presentation.model.SubscriberDetailsState;
 import com.globant.practice.presentation.presenter.SubscriberDetailsPresenter;
 import com.globant.practice.presentation.view.Decoration;
 import com.globant.practice.presentation.view.adapter.SubscriberDetailsAdapter;
-
 import javax.inject.Inject;
 
 /**
@@ -30,6 +30,7 @@ public class SubscriberDetailsFragment extends Fragment implements SubscriberDet
     private ProgressDialog fetchSubscriberDetailsIndicator;
     private RecyclerView subscriberDetailsRecyclerView;
     private SubscriberDetailsAdapter subscriberDetailsAdapter;
+    private SubscriberDetailsActions subscriberDetailsActions;
     @Inject
     SubscriberDetailsPresenter presenter;
 
@@ -85,6 +86,19 @@ public class SubscriberDetailsFragment extends Fragment implements SubscriberDet
         subscriberDetailsRecyclerView.setItemAnimator(new DefaultItemAnimator());
         subscriberDetailsRecyclerView.setLayoutManager(new LinearLayoutManager(view.getContext(), LinearLayoutManager.VERTICAL, false));
         subscriberDetailsRecyclerView.addItemDecoration(new Decoration(view.getContext(), Decoration.VERTICAL_LIST));
+    }
+
+    /**
+     * Initializes the context and the SubscriberDetailsActions instance
+     *
+     * @param context
+     */
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (getActivity() instanceof SubscriberDetailsActions) {
+            subscriberDetailsActions = (SubscriberDetailsActions) getActivity();
+        }
     }
 
     /**
@@ -155,7 +169,9 @@ public class SubscriberDetailsFragment extends Fragment implements SubscriberDet
      */
     @Override
     public void onProfileNameClick(String htmlUrl) {
-        //TODO Charge the htmlUrl into a WebView
+        if (subscriberDetailsActions != null) {
+            subscriberDetailsActions.nameSelected(htmlUrl, getString(R.string.subscriber_detail_type_profile));
+        }
     }
 
     /**
@@ -165,6 +181,29 @@ public class SubscriberDetailsFragment extends Fragment implements SubscriberDet
      */
     @Override
     public void onRepositoryClick(String htmlUrl) {
-        //TODO Charge the htmlUrl into a WebView
+        if (subscriberDetailsActions != null) {
+            subscriberDetailsActions.repositorySelected(htmlUrl, getString(R.string.subscriber_detail_type_repository));
+        }
+    }
+
+    /**
+     * Manages the actions between SubscriberDetailsFragment and HomeActivity
+     */
+    public interface SubscriberDetailsActions {
+        /**
+         * Indicates that the user wants to see the profile of the subscriber
+         *
+         * @param htmlUrl    url with the profile address of the subscriber
+         * @param detailType Indicates the detail type of the user wants to see, in this case profile
+         */
+        void nameSelected(String htmlUrl, String detailType);
+
+        /**
+         * Indicates that the user wants to see the repository of the subscriber
+         *
+         * @param htmlUrl    url with the repository address of the subscriber
+         * @param detailType Indicates the detail type of the user wants to see, in this case repository
+         */
+        void repositorySelected(String htmlUrl, String detailType);
     }
 }

--- a/app/src/main/java/com/globant/practice/presentation/view/fragment/SubscriberListFragment.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/fragment/SubscriberListFragment.java
@@ -108,8 +108,8 @@ public class SubscriberListFragment extends Fragment implements SubscriberListVi
      * Detach the view to the presenter
      */
     @Override
-    public void onDetach() {
-        super.onDetach();
+    public void onPause() {
+        super.onPause();
         presenter.detachView();
     }
 

--- a/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientFragment.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientFragment.java
@@ -20,7 +20,6 @@ import com.globant.practice.PracticeApplication;
 import com.globant.practice.R;
 import com.globant.practice.presentation.model.WebClientState;
 import com.globant.practice.presentation.presenter.WebClientPresenter;
-
 import javax.inject.Inject;
 
 /**
@@ -108,6 +107,7 @@ public class WebClientFragment extends Fragment implements WebClientView {
         webPageLoadingIndicator = new ProgressDialog(view.getContext());
         webPageLoadingIndicator.setIndeterminate(true);
         webPageLoadingIndicator.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+        webPageLoadingIndicator.setMessage(String.format(getString(R.string.web_client_progress_dialog_message), getArguments().getString(DETAIL_TYPE_KEY)));
         webViewState = savedInstanceState;
     }
 
@@ -118,7 +118,7 @@ public class WebClientFragment extends Fragment implements WebClientView {
     public void onResume() {
         super.onResume();
         presenter.attachView(this);
-        presenter.loadWebPage(getArguments().getString(HTML_URL_KEY), getArguments().getString(DETAIL_TYPE_KEY));
+        presenter.loadWebPage(getArguments().getString(HTML_URL_KEY));
     }
 
     /**
@@ -130,17 +130,10 @@ public class WebClientFragment extends Fragment implements WebClientView {
     @Override
     public void render(@NonNull WebClientState webClientState) {
         if (webViewState != null) {
-            if (webClientState.isLoading()) {
-                webPageLoadingIndicator.setMessage(String.format(getString(R.string.web_client_progress_dialog_message), webClientState.getDetailType()));
-                webPageLoadingIndicator.show();
-                webClientWebView.restoreState(webViewState);
-                webViewState = null;
-            } else {
-                webClientWebView.restoreState(webViewState);
-                webViewState = null;
-            }
+            webClientWebView.restoreState(webViewState);
+            webViewState = null;
+            webPageLoadingIndicator.show();
         } else if (webClientState.isLoading()) {
-            webPageLoadingIndicator.setMessage(String.format(getString(R.string.web_client_progress_dialog_message), webClientState.getDetailType()));
             webClientWebView.loadUrl(webClientState.getHtmlUrl());
             webPageLoadingIndicator.show();
         } else if (!TextUtils.isEmpty(webClientState.getError())) {

--- a/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientFragment.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientFragment.java
@@ -118,15 +118,6 @@ public class WebClientFragment extends Fragment implements WebClientView {
     }
 
     /**
-     * Detach the view on the presenter
-     */
-    @Override
-    public void onDetach() {
-        super.onDetach();
-        presenter.detachView();
-    }
-
-    /**
      * Shows or dismiss the progress dialog, load the web page on the WebView depending of the
      * webClientState
      *
@@ -139,7 +130,7 @@ public class WebClientFragment extends Fragment implements WebClientView {
             webClientWebView.setWebViewClient(webViewLoadState);
             webClientWebView.loadUrl(webClientState.getHtmlUrl());
             webPageLoadingIndicator.show();
-        } else if (!TextUtils.isEmpty(webClientState.getError()) && webClientState.isErrorShowing()) {
+        } else if (!TextUtils.isEmpty(webClientState.getError())) {
             webPageLoadingIndicator.dismiss();
             showErrorMessage(webClientState.getError());
         } else {
@@ -153,7 +144,7 @@ public class WebClientFragment extends Fragment implements WebClientView {
     @Override
     public void onPause() {
         super.onPause();
-        presenter.viewOnPauseState();
+        presenter.detachView();
     }
 
     /**

--- a/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientFragment.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientFragment.java
@@ -1,0 +1,152 @@
+package com.globant.practice.presentation.view.fragment;
+
+import android.annotation.TargetApi;
+import android.app.Fragment;
+import android.app.ProgressDialog;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import com.globant.practice.PracticeApplication;
+import com.globant.practice.R;
+import com.globant.practice.presentation.model.WebClientState;
+import com.globant.practice.presentation.presenter.WebClientPresenter;
+import javax.inject.Inject;
+
+/**
+ * Initializes and manage the communication with the presenter, initializes and manage the view items,
+ * load the web page and manages the states of the load process.
+ */
+public class WebClientFragment extends Fragment implements WebClientView {
+    private static final String HTML_URL_KEY = "url";
+    private static final String DETAIL_TYPE_KEY = "type";
+    private WebView webClientWebView;
+    private ProgressDialog getWebPageIndicator;
+    @Inject
+    WebClientPresenter presenter;
+
+    /**
+     * Manages the states of the web page load process.
+     */
+    private WebViewClient webViewLoadState = new WebViewClient() {
+        @Override
+        public void onPageFinished(WebView view, String url) {
+            super.onPageFinished(view, url);
+            presenter.getWebPageCompleted();
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
+            super.onReceivedError(view, errorCode, description, failingUrl);
+            presenter.getWebPageError();
+        }
+
+        @TargetApi(android.os.Build.VERSION_CODES.M)
+        @Override
+        public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+            onReceivedError(view, error.getErrorCode(), error.getDescription().toString(), request.getUrl().toString());
+        }
+    };
+
+    /**
+     * Returns a new instance if WebClientFragment with the necessary arguments that the fragment needs
+     *
+     * @param htmlUrl    url of the profile or repository address
+     * @param detailType Indicates if the web page is a profile or a repository
+     * @return new instance of WebClientFragment with the necessary arguments
+     */
+    public static WebClientFragment newInstance(String htmlUrl, String detailType) {
+        WebClientFragment fragment = new WebClientFragment();
+        Bundle bundle = new Bundle();
+        bundle.putString(HTML_URL_KEY, htmlUrl);
+        bundle.putString(DETAIL_TYPE_KEY, detailType);
+        fragment.setArguments(bundle);
+        return fragment;
+    }
+
+    /**
+     * Inflates the fragment_web_client and initializes the WebClientPresenter
+     *
+     * @param inflater
+     * @param container
+     * @param savedInstanceState
+     * @return
+     */
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        ((PracticeApplication) getActivity().getApplication()).getApplicationComponent().inject(this);
+        return inflater.inflate(R.layout.fragment_web_client, container, false);
+    }
+
+    /**
+     * Initializes the view items and set the ActionBar title
+     *
+     * @param view
+     * @param savedInstanceState
+     */
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        if (!getArguments().getString(DETAIL_TYPE_KEY).isEmpty()) {
+            ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(getArguments().getString(DETAIL_TYPE_KEY));
+        }
+        webClientWebView = (WebView) view.findViewById(R.id.web_client_webview);
+        getWebPageIndicator = new ProgressDialog(view.getContext());
+        getWebPageIndicator.setIndeterminate(true);
+        getWebPageIndicator.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+    }
+
+    /**
+     * Attach the view on the presenter and initializes the web page load process
+     */
+    @Override
+    public void onResume() {
+        super.onResume();
+        presenter.attachView(this);
+        presenter.getWebPage(getArguments().getString(HTML_URL_KEY), getArguments().getString(DETAIL_TYPE_KEY));
+    }
+
+    /**
+     * Detach the view on the presenter
+     */
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        presenter.detachView();
+    }
+
+    /**
+     * Shows or dismiss the progress dialog, load the web page on the WebView depending of the
+     * webClientState
+     *
+     * @param webClientState instance of the WebClientState
+     */
+    @Override
+    public void render(@NonNull WebClientState webClientState) {
+        if (webClientState.isLoading()) {
+            getWebPageIndicator.setMessage(String.format(getString(R.string.web_client_progress_dialog_message), webClientState.getDetailType()));
+            webClientWebView.setWebViewClient(webViewLoadState);
+            webClientWebView.loadUrl(webClientState.getHtmlUrl());
+            getWebPageIndicator.show();
+        } else {
+            getWebPageIndicator.dismiss();
+        }
+    }
+
+    /**
+     * Indicates to the presenter that the fragment is going into onPause state
+     */
+    @Override
+    public void onPause() {
+        super.onPause();
+        presenter.viewOnPauseState();
+    }
+}

--- a/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientFragment.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientFragment.java
@@ -3,9 +3,12 @@ package com.globant.practice.presentation.view.fragment;
 import android.annotation.TargetApi;
 import android.app.Fragment;
 import android.app.ProgressDialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -27,7 +30,7 @@ public class WebClientFragment extends Fragment implements WebClientView {
     private static final String HTML_URL_KEY = "url";
     private static final String DETAIL_TYPE_KEY = "type";
     private WebView webClientWebView;
-    private ProgressDialog getWebPageIndicator;
+    private ProgressDialog webPageIndicator;
     @Inject
     WebClientPresenter presenter;
 
@@ -38,14 +41,14 @@ public class WebClientFragment extends Fragment implements WebClientView {
         @Override
         public void onPageFinished(WebView view, String url) {
             super.onPageFinished(view, url);
-            presenter.getWebPageCompleted();
+            presenter.webPageLoadComplete();
         }
 
         @SuppressWarnings("deprecation")
         @Override
         public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
             super.onReceivedError(view, errorCode, description, failingUrl);
-            presenter.getWebPageError();
+            presenter.webPageError(failingUrl);
         }
 
         @TargetApi(android.os.Build.VERSION_CODES.M)
@@ -99,9 +102,9 @@ public class WebClientFragment extends Fragment implements WebClientView {
             ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(getArguments().getString(DETAIL_TYPE_KEY));
         }
         webClientWebView = (WebView) view.findViewById(R.id.web_client_webview);
-        getWebPageIndicator = new ProgressDialog(view.getContext());
-        getWebPageIndicator.setIndeterminate(true);
-        getWebPageIndicator.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+        webPageIndicator = new ProgressDialog(view.getContext());
+        webPageIndicator.setIndeterminate(true);
+        webPageIndicator.setProgressStyle(ProgressDialog.STYLE_SPINNER);
     }
 
     /**
@@ -111,7 +114,7 @@ public class WebClientFragment extends Fragment implements WebClientView {
     public void onResume() {
         super.onResume();
         presenter.attachView(this);
-        presenter.getWebPage(getArguments().getString(HTML_URL_KEY), getArguments().getString(DETAIL_TYPE_KEY));
+        presenter.loadWebPage(getArguments().getString(HTML_URL_KEY), getArguments().getString(DETAIL_TYPE_KEY));
     }
 
     /**
@@ -132,12 +135,15 @@ public class WebClientFragment extends Fragment implements WebClientView {
     @Override
     public void render(@NonNull WebClientState webClientState) {
         if (webClientState.isLoading()) {
-            getWebPageIndicator.setMessage(String.format(getString(R.string.web_client_progress_dialog_message), webClientState.getDetailType()));
+            webPageIndicator.setMessage(String.format(getString(R.string.web_client_progress_dialog_message), webClientState.getDetailType()));
             webClientWebView.setWebViewClient(webViewLoadState);
             webClientWebView.loadUrl(webClientState.getHtmlUrl());
-            getWebPageIndicator.show();
+            webPageIndicator.show();
+        } else if (!TextUtils.isEmpty(webClientState.getError()) && webClientState.isErrorShowing()) {
+            webPageIndicator.dismiss();
+            showErrorMessage(webClientState.getError());
         } else {
-            getWebPageIndicator.dismiss();
+            webPageIndicator.dismiss();
         }
     }
 
@@ -148,5 +154,28 @@ public class WebClientFragment extends Fragment implements WebClientView {
     public void onPause() {
         super.onPause();
         presenter.viewOnPauseState();
+    }
+
+    /**
+     * Gets the error message text from the resource file
+     *
+     * @return Error message text
+     */
+    @Override
+    public String getErrorMessageText() {
+        return getString(R.string.net_error_message);
+    }
+
+    /**
+     * Shows a AlertDialog to inform at the user that the api call have an error
+     */
+    private void showErrorMessage(String message) {
+        new AlertDialog.Builder(getView().getContext()).setTitle(message)
+                .setCancelable(false).setPositiveButton(getString(R.string.accept_text), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.cancel();
+            }
+        }).create().show();
     }
 }

--- a/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientFragment.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientFragment.java
@@ -30,7 +30,7 @@ public class WebClientFragment extends Fragment implements WebClientView {
     private static final String HTML_URL_KEY = "url";
     private static final String DETAIL_TYPE_KEY = "type";
     private WebView webClientWebView;
-    private ProgressDialog webPageIndicator;
+    private ProgressDialog webPageLoadingIndicator;
     @Inject
     WebClientPresenter presenter;
 
@@ -102,9 +102,9 @@ public class WebClientFragment extends Fragment implements WebClientView {
             ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(getArguments().getString(DETAIL_TYPE_KEY));
         }
         webClientWebView = (WebView) view.findViewById(R.id.web_client_webview);
-        webPageIndicator = new ProgressDialog(view.getContext());
-        webPageIndicator.setIndeterminate(true);
-        webPageIndicator.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+        webPageLoadingIndicator = new ProgressDialog(view.getContext());
+        webPageLoadingIndicator.setIndeterminate(true);
+        webPageLoadingIndicator.setProgressStyle(ProgressDialog.STYLE_SPINNER);
     }
 
     /**
@@ -135,15 +135,15 @@ public class WebClientFragment extends Fragment implements WebClientView {
     @Override
     public void render(@NonNull WebClientState webClientState) {
         if (webClientState.isLoading()) {
-            webPageIndicator.setMessage(String.format(getString(R.string.web_client_progress_dialog_message), webClientState.getDetailType()));
+            webPageLoadingIndicator.setMessage(String.format(getString(R.string.web_client_progress_dialog_message), webClientState.getDetailType()));
             webClientWebView.setWebViewClient(webViewLoadState);
             webClientWebView.loadUrl(webClientState.getHtmlUrl());
-            webPageIndicator.show();
+            webPageLoadingIndicator.show();
         } else if (!TextUtils.isEmpty(webClientState.getError()) && webClientState.isErrorShowing()) {
-            webPageIndicator.dismiss();
+            webPageLoadingIndicator.dismiss();
             showErrorMessage(webClientState.getError());
         } else {
-            webPageIndicator.dismiss();
+            webPageLoadingIndicator.dismiss();
         }
     }
 

--- a/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientView.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientView.java
@@ -1,0 +1,18 @@
+package com.globant.practice.presentation.view.fragment;
+
+import com.globant.practice.presentation.model.WebClientState;
+import com.globant.practice.presentation.view.BaseView;
+
+/**
+ * Manages the actions between WebClientPresenter and WebClientFragment
+ * Created by jonathan.vargas on 4/05/2017.
+ */
+
+public interface WebClientView extends BaseView {
+    /**
+     * Renders the view items depending of the WebClientState
+     *
+     * @param webClientState instance of the WebClientState
+     */
+    void render(WebClientState webClientState);
+}

--- a/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientView.java
+++ b/app/src/main/java/com/globant/practice/presentation/view/fragment/WebClientView.java
@@ -15,4 +15,11 @@ public interface WebClientView extends BaseView {
      * @param webClientState instance of the WebClientState
      */
     void render(WebClientState webClientState);
+
+    /**
+     * Gets the error message text from the resource file
+     *
+     * @return Error message text
+     */
+    String getErrorMessageText();
 }

--- a/app/src/main/res/layout/fragment_web_client.xml
+++ b/app/src/main/res/layout/fragment_web_client.xml
@@ -1,0 +1,11 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.globant.practice.presentation.view.fragment.WebClientFragment">
+
+    <WebView
+        android:id="@+id/web_client_webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</FrameLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -11,4 +11,7 @@
     <string name="subscriber_details_following">Siguiendo: %d</string>
     <string name="subscriber_details_publicrepos">Repositorios: %d</string>
     <string name="subscriber_details_location">Ubicación: %s</string>
+    <string name="subscriber_detail_type_profile">Perfil</string>
+    <string name="subscriber_details_profile_layout_tag">Repositorio</string>
+    <string name="web_client_progress_dialog_message">Obteniendo %s, por favor espere</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,7 @@
     <string name="subscriber_details_publicrepos">Repositories: %d</string>
     <string name="subscriber_details_location">Location: %s</string>
     <string name="subscriber_details_profile_layout_tag">profileLayout</string>
+    <string name="subscriber_detail_type_profile">Profile</string>
+    <string name="subscriber_detail_type_repository">Repository</string>
+    <string name="web_client_progress_dialog_message">Getting %s, please wait</string>
 </resources>


### PR DESCRIPTION
Added the functionality of load the webpage  of the Profile or the Repository selected with the messages of load and error depending of the state of the load process.

![screenshot_2017-05-04-18-37-47-790_com globant practice](https://cloud.githubusercontent.com/assets/5483974/25729233/b3e4c534-30f9-11e7-8431-46d5353fe664.png)
![screenshot_2017-05-04-18-39-02-916_com globant practice](https://cloud.githubusercontent.com/assets/5483974/25729234/b3e8ee02-30f9-11e7-80a7-0a4ccbf53d68.png)
